### PR TITLE
Avoid conflict on newer versions of mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "sinon": "^1.17.3"
   },
   "peerDependencies": {
-    "aws-sdk": "^2.3.4",
-    "mocha": "^2.4.5"
+    "aws-sdk": "^2.3.4"
   },
   "repository": {
     "type" : "git",


### PR DESCRIPTION
Since the library does not depend on mocha for runtime, we should let projects that depend on mock-aws-sinon use any version of mocha.