### PR TITLE
Allow multiple teardowns and setups and an easier means of overriding stubs

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,15 @@ var getKey = function(service, method) {
     return service.toLowerCase() + '_' + method.toLowerCase();
 };
 
+// Support sinon pre and post v2
+var stub = function(obj, key, func) {
+    if (sinon.stub.callsFake) {
+        sinon.stub(obj, key).callsFake(func);
+    } else {
+        sinon.stub(obj, key, func);
+    }
+}
+
 var processRequest = function(cb) {
 
     var requestKey = getKey(this.service.serviceIdentifier, this.operation);
@@ -56,7 +65,8 @@ var stubRequestSend = function() {
         return;
     }
 
-    sinon.stub(AWS.Request.prototype, "send", processRequest);
+    stub(AWS.Request.prototype, "send", processRequest);
+
     stubbedRequestSend = true;
 }
 
@@ -70,7 +80,7 @@ module.exports = function(service, method, func) {
         
         cachedStubs[stubKey] = function() {} // is never run
 
-        sinon.stub(cachedStubs, stubKey, func);
+        stub(cachedStubs, stubKey, func);
 
         cachedStubs[stubKey].restore = function() {
             // override default stub behaviour here to account for our

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ module.exports = function(service, method, func) {
     
     var stubKey = getKey(service, method);
 
-    if (!cachedStubs[stubKey]) {
+    if (func || !cachedStubs[stubKey]) {
         
         cachedStubs[stubKey] = function() {} // is never run
 
@@ -85,5 +85,7 @@ module.exports = function(service, method, func) {
 }
 
 module.exports.restore = function() {
+    cachedStubs = {};
+    stubbedRequestSend = false;
     AWS.Request.prototype.send.restore();
 }

--- a/index.js
+++ b/index.js
@@ -47,11 +47,14 @@ var processRequest = function(cb) {
     }
 
 
-    var possibleData = cachedStubs[requestKey](this.params, callback);
-    if (typeof possibleData !== 'undefined') {
-        callback(null, possibleData);
+    try {
+        var possibleData = cachedStubs[requestKey](this.params, callback);
+        if (typeof possibleData !== 'undefined') {
+            callback(null, possibleData);
+        }
+    } catch (e) {
+        callback(e, null);
     }
-
     
 };
 

--- a/index.js
+++ b/index.js
@@ -47,14 +47,11 @@ var processRequest = function(cb) {
     }
 
 
-    try {
-        var possibleData = cachedStubs[requestKey](this.params, callback);
-        if (typeof possibleData !== 'undefined') {
-            callback(null, possibleData);
-        }
-    } catch (e) {
-        callback(e, null);
+    var possibleData = cachedStubs[requestKey](this.params, callback);
+    if (typeof possibleData !== 'undefined') {
+        callback(null, possibleData);
     }
+
     
 };
 

--- a/index.js
+++ b/index.js
@@ -66,6 +66,18 @@ var stubRequestSend = function() {
     }
 
     stub(AWS.Request.prototype, "send", processRequest);
+    stub(AWS.Request.prototype, "promise", function () {
+        var request = this;
+        return new Promise((resolve, reject) => {
+            processRequest.call(request, ((err, data) => {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve(data);
+                }
+            }));
+        });
+    });
 
     stubbedRequestSend = true;
 }
@@ -98,4 +110,5 @@ module.exports.restore = function() {
     cachedStubs = {};
     stubbedRequestSend = false;
     AWS.Request.prototype.send.restore();
+    AWS.Request.prototype.promise.restore();
 }

--- a/index.js
+++ b/index.js
@@ -109,6 +109,12 @@ module.exports = function(service, method, func) {
 module.exports.restore = function() {
     cachedStubs = {};
     stubbedRequestSend = false;
-    AWS.Request.prototype.send.restore();
-    AWS.Request.prototype.promise.restore();
+
+    if (AWS.Request.prototype.send.restore) {
+        AWS.Request.prototype.send.restore();
+    }
+    
+    if (AWS.Request.prototype.promise.restore) {
+        AWS.Request.prototype.promise.restore();
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mock-aws-sinon",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mock-aws-sinon",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mock-aws-sinon",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mock-aws-sinon",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -15,7 +15,7 @@
   },
   "peerDependencies": {
     "aws-sdk": "^2.3.4",
-    "mocha": "^2.4.5"
+    "sinon": "^4.1.3"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mock-aws-sinon",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -11,14 +11,14 @@
   "devDependencies": {
     "aws-sdk": "^2.3.4",
     "mocha": "^2.4.5",
-    "sinon": "^1.17.3"
+    "sinon": "^4.0.1"
   },
   "peerDependencies": {
     "aws-sdk": "^2.3.4",
     "mocha": "^2.4.5"
   },
   "repository": {
-    "type" : "git",
-    "url" : "https://github.com/gdnmobilelab/mock-aws-sinon.git"
+    "type": "git",
+    "url": "https://github.com/gdnmobilelab/mock-aws-sinon.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "devDependencies": {
     "aws-sdk": "^2.3.4",
-    "mocha": "^2.4.5",
+    "mocha": "5.0.4",
     "sinon": "^4.0.1"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mock-aws-sinon",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ Then, rather than call `sinon.stub`, you can call this module as a function, whi
         assert.equal(response.an, 'object') // true
     })
     
-If you wish to use the sinon vertification helpers, you can get run the function again to retrieve the same
+If you wish to use the sinon verification helpers, you can get run the function again to retrieve the same
 stub. So instead of doing:
 
     AWS.S3.prototype.getObject.calledOnce()

--- a/tests/index.js
+++ b/tests/index.js
@@ -95,19 +95,4 @@ describe("AWS Mock Sinon", function() {
             done();
         })
     })
-
-    it("Should allow you to throw an error", function(done) {
-        MockAWSSinon('S3', 'putObject', function(params) {
-            throw new Error('Hello World');
-        })
-
-        new AWS.S3().putObject({
-            test: 'test'
-        }, function(err, resp) {
-            assert.equal(err.message, 'Hello World');
-            assert.equal(resp, null)
-            assert.equal(MockAWSSinon('S3', 'putObject').calledOnce, true);            
-            done();
-        })
-    })
 })

--- a/tests/index.js
+++ b/tests/index.js
@@ -43,6 +43,42 @@ describe("AWS Mock Sinon", function() {
             assert.equal(resp, "hello");
         })
     })
-
     
+    it("Should allow you to easily override a stub", function(done) {
+        MockAWSSinon('S3', 'putObject', function(params, cb) {
+            return "hello"
+        })
+
+        MockAWSSinon('S3', 'putObject', function(params, cb) {
+            return "world"
+        })
+
+        new AWS.S3().putObject({
+            test: 'test'
+        }, function(err, resp) {
+            assert.equal(resp, "world");
+            assert.equal(MockAWSSinon('S3', 'getObject').calledOnce, true);            
+            done();
+        })
+    })
+
+    it("Should allow multiple teardowns and setups", function(done) {
+        MockAWSSinon('S3', 'putObject', function(params, cb) {
+            return "hello"
+        })
+
+        MockAWSSinon.restore();
+
+        MockAWSSinon('S3', 'putObject', function(params, cb) {
+            return "world"
+        })
+
+        new AWS.S3().putObject({
+            test: 'test'
+        }, function(err, resp) {
+            assert.equal(resp, "world");
+            assert.equal(MockAWSSinon('S3', 'putObject').calledOnce, true);            
+            done();
+        })
+    })
 })

--- a/tests/index.js
+++ b/tests/index.js
@@ -4,8 +4,11 @@ var assert = require('assert');
 
 describe("AWS Mock Sinon", function() {
 
-    it("Should mock a request", function(done) {
+    afterEach(() => {
+        MockAWSSinon.restore();
+    });
 
+    it("Should mock a request", function(done) {
         MockAWSSinon('S3', 'getObject').returns({
             what: 'yes'
         });
@@ -17,6 +20,17 @@ describe("AWS Mock Sinon", function() {
             assert.equal(MockAWSSinon('S3', 'getObject').calledOnce, true);
             done();
         })
+    });
+    it("Should work with promises", async function() {
+        MockAWSSinon('S3', 'getObject').returns({
+            what: 'yes'
+        });
+        var resp = await new AWS.S3().getObject({
+            Bucket: 'what'
+        }).promise();
+
+        assert.equal(resp.what, 'yes');
+        assert.equal(MockAWSSinon('S3', 'getObject').calledOnce, true);
     });
 
     it("Should allow you to use a function that returns immediately", function(done) {
@@ -57,7 +71,7 @@ describe("AWS Mock Sinon", function() {
             test: 'test'
         }, function(err, resp) {
             assert.equal(resp, "world");
-            assert.equal(MockAWSSinon('S3', 'getObject').calledOnce, true);            
+            assert.equal(MockAWSSinon('S3', 'putObject').calledOnce, true);
             done();
         })
     })

--- a/tests/index.js
+++ b/tests/index.js
@@ -95,4 +95,19 @@ describe("AWS Mock Sinon", function() {
             done();
         })
     })
+
+    it("Should allow you to throw an error", function(done) {
+        MockAWSSinon('S3', 'putObject', function(params) {
+            throw new Error('Hello World');
+        })
+
+        new AWS.S3().putObject({
+            test: 'test'
+        }, function(err, resp) {
+            assert.equal(err.message, 'Hello World');
+            assert.equal(resp, null)
+            assert.equal(MockAWSSinon('S3', 'putObject').calledOnce, true);            
+            done();
+        })
+    })
 })

--- a/tests/index.js
+++ b/tests/index.js
@@ -95,4 +95,8 @@ describe("AWS Mock Sinon", function() {
             done();
         })
     })
+
+    it("Let's you call restore before setting anything", function() {
+        MockAWSSinon.restore();
+    });
 })


### PR DESCRIPTION
Came across a few issues when using this library in a fairly large test suite. The biggest one was with setups and teardowns. We have a slightly unique case where some tests mock parts of AWS and others send real requests. We'd mock a resource, `stubRequestSend` would be called and set `stubbedRequestSend` to `true` and then at the end of the test we'd call `restore` so a subsequent test could use the real AWS.Request. Then another test would come along, create a mock, `stubRequestSend` would be called but `stubbedRequestSend` would already be set to true so it would return before stubbing and now instead of a mock we are sending real requests (thankfully failing ones). This change simply makes it so that on "restore" that value gets reset (we also clear out all `cachedStubs`)

The other small issue was with overrides. We have a generic "mockSQS" or some such method that creates a bunch of mocks for a service that might get called on `beforeAll`". If we wanted to override one of those mocks to test something like error recovery for a failing endpoint you'd first need to restore the original stub to clear out the cache and then redefine your function. But furthermore, you'd need to restore all _potentially_ mocked functions in `afterAll` to make sure that they could be overriden during the next test's `beforeAll`. So this just adds a small check that says "if a function is being passed in, override the current stub". Hopefully this way it can remain backwards compatible.